### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -36,10 +36,4 @@ Discord Events are in ./event dirrectory. you can edit them as your need ... nor
 
 [/](https://malleable-traveling-moonstone.glitch.me/) An activity page to know if the bot is available. This page is designed to be ping by [uptimerobot.com](http://uptimerobot.com).
 
-## Made by [Glitch](https://glitch.com/)
-
-**Glitch** is the friendly community where you'll build the app of your dreams. Glitch lets you instantly create, remix, edit, and host an app, bot or site, and you can invite collaborators or helpers to simultaneously edit code with you.
-
-Find out more [about Glitch](https://glitch.com/about).
-
-( ᵔ ᴥ ᵔ )
+[![Run on Repl.it](https://repl.it/badge/github/PatrickPIGNOL/ObjectBasedDiscordBot)](https://repl.it/github/PatrickPIGNOL/ObjectBasedDiscordBot)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).